### PR TITLE
Pitch mapping function

### DIFF
--- a/astronify/series.py
+++ b/astronify/series.py
@@ -61,9 +61,13 @@ class PitchMap():
             if not Parameter.VAR_KEYWORD in param_types:
                 for arg_name in list(self.pitch_map_args):
                     if not arg_name in signature(self.pitch_map_func).parameters:
-                        wstr = "{} is not accepted by the pitch mapping function and will be removed".format(arg_name)
+                        wstr = "{} is not accepted by the pitch mapping function and will be ignored".format(arg_name)
                         warnings.warn(wstr, InputWarning)
                         del self.pitch_map_args[arg_name]
+
+    def __call__(self, data):
+        self._check_func_args()
+        return self.pitch_map_func(data, **self.pitch_map_args)
 
     @property
     def pitch_map_func(self):
@@ -183,8 +187,7 @@ class SoniSeries():
         data.meta["asf_note_duration"] = duration
         data.meta["asf_spacing"] = spacing
         
-        data["asf_pitch"] = self.pitch_mapper.pitch_map_func(data[self.val_col],
-                                                             **self.pitch_mapper.pitch_map_args)
+        data["asf_pitch"] = self.pitch_mapper(data[self.val_col])
         data["asf_onsets"] = [x for x in (data[self.time_col] - data[self.time_col][0])/exptime*spacing]
 
     def _pyo_play(self):

--- a/astronify/utils.exceptions.py
+++ b/astronify/utils.exceptions.py
@@ -1,0 +1,15 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+"""
+Custom exceptions used in astronify
+"""
+
+from astropy.utils.exceptions import AstropyWarning
+
+
+class InputWarning(AstropyWarning):
+    """
+    Warning to be issued when user input is incorrect in
+    some way but doesn't prevent the function from running.
+    """
+    pass

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,4 +1,4 @@
-.. image:: docs/_static/astronify-TEXT.png
+.. image:: _static/astronify-TEXT.png
     :width: 800
     :alt: Astronify logo
 


### PR DESCRIPTION
This PR fixes and improves the pitch mapping function and introduced a new PitchMap class that holds the function and argument setting so that sonification settings can be changed at will.

Changes:
- New `PitchMap` function encapsulated all data->pitch settings.
- When `SoniSeries` calls the pitch mapping function it all adds the arguments, giving the user control over the mapping settings.
- Bugfixing and enhancement of `data_to_pitch` function to encompass all issues from  https://github.com/spacetelescope/astronify/issues/3
- Addition of an exceptions file for Astronify exceptions and warnings, currently only includes `InputWarning`

Example of how to use the new functionality:
```
import astronify

kep12b_lc = lightkurve.search_lightcurvefile("KIC 11804465", cadence="long, quarter=1).download_all()[0].SAP_FLUX.to_table()

kep12b_obj = astronify.SoniSeries(kep12b_lc)
kep12b_obj.pitch_mapper.pitch_map_args["stretch"]='asinh'

kep12b_obj.sonify()
kep12b_obj.play()

kep12b_obj.stop()
```