### PR TITLE
Gain: consistency and settings

### DIFF
--- a/astronify/series.py
+++ b/astronify/series.py
@@ -219,16 +219,18 @@ class SoniSeries():
         The asf_pitch column will contain the sonified data in Hz.
         The asf_onsets column will contain the start time for each note in seconds from the first note.
         Metadata will also be added to the table giving information about the duration and spacing 
-        of the sonified pitches.
+        of the sonified pitches, as well as an adjustable gain.
         """
         duration = 0.5 # note duration in seconds
         spacing = 0.01 # spacing between notes in seconds
+        gain = 0.05 # multiplier argument, in this case gain in the generated sine wave
         data = self.data
         exptime = np.median(np.diff(data[self.time_col]))
 
         data.meta["asf_exposure_time"] = exptime
         data.meta["asf_note_duration"] = duration
         data.meta["asf_spacing"] = spacing
+        data.meta["asf_gain"] = gain
         
         data["asf_pitch"] = self.pitch_mapper(data[self.val_col])
         data["asf_onsets"] = [x for x in (data[self.time_col] - data[self.time_col][0])/exptime*spacing]
@@ -249,12 +251,13 @@ class SoniSeries():
         duration = self.data.meta["asf_note_duration"]
         pitches = np.repeat(self.data["asf_pitch"], 2)
         delays = np.repeat(self.data["asf_onsets"], 2)
+        gain = self.data.meta["asf_gain"]
 
         # TODO: This doesn't seem like the best way to do this, but I don't know
         # how to make it better
         env = pyo.Linseg(list=[(0, 0), (0.01, 1), (duration - 0.1, 1),
                                (duration - 0.05, 0.5), (duration - 0.005, 0)],
-                         mul=[.05 for i in range(len(pitches))]).play(
+                         mul=[gain for i in range(len(pitches))]).play(
                              delay=list(delays), dur=duration)
 
         self.streams = pyo.Sine(list(pitches), 0, env).out(delay=list(delays),
@@ -275,6 +278,7 @@ class SoniSeries():
         duration = self.data.meta["asf_note_duration"]
         pitches = np.repeat(self.data["asf_pitch"], 2)
         delays = np.repeat(self.data["asf_onsets"], 2)
+        gain = self.data.meta["asf_gain"]
 
         # Making sure we have a clean server
         if self.server.getIsBooted():
@@ -286,7 +290,7 @@ class SoniSeries():
 
         env = pyo.Linseg(list=[(0, 0), (0.1, 1), (duration - 0.1, 1),
                                (duration - 0.05, 0.5), (duration - 0.005, 0)],
-                         mul=[0.05 for i in range(len(pitches))]).play(
+                         mul=[gain for i in range(len(pitches))]).play(
                              delay=list(delays), dur=duration)
         sine = pyo.Sine(list(pitches), 0, env).out(delay=list(delays),
                                                    dur=duration)

--- a/astronify/series.py
+++ b/astronify/series.py
@@ -215,7 +215,7 @@ class SoniSeries():
 
     def sonify(self):
         """
-        Perform the sonification, two columns will be added to teh data table: asf_pitch, and asf_onsets. 
+        Perform the sonification, two columns will be added to the data table: asf_pitch, and asf_onsets. 
         The asf_pitch column will contain the sonified data in Hz.
         The asf_onsets column will contain the start time for each note in seconds from the first note.
         Metadata will also be added to the table giving information about the duration and spacing 
@@ -254,7 +254,7 @@ class SoniSeries():
         # how to make it better
         env = pyo.Linseg(list=[(0, 0), (0.01, 1), (duration - 0.1, 1),
                                (duration - 0.05, 0.5), (duration - 0.005, 0)],
-                         mul=[.1 for i in range(len(pitches))]).play(
+                         mul=[.05 for i in range(len(pitches))]).play(
                              delay=list(delays), dur=duration)
 
         self.streams = pyo.Sine(list(pitches), 0, env).out(delay=list(delays),


### PR DESCRIPTION
Originally the gain for replay was set at 0.1 while write was 0.05. First commits make these match, last commit adds the ability for users to set the value dynamically.

Settings such as gain, duration, and spacing may need to be at a different level than where I've put gain for now. Are they specific to a pitch map (and set of pyo etc arguments), or individual sonified objects? Are they general astronify settings? As we start making these user-modifiable this is something we'll have to move, and I'd appreciate input as someone who just picked this up. 