### PR TITLE
Adding more sonification options

### DIFF
--- a/astronify/series.py
+++ b/astronify/series.py
@@ -136,6 +136,10 @@ class SoniSeries():
         self.val_col = val_col
         self.data = data
 
+        # Default specs
+        self.note_duration = 0.5 # note duration in seconds
+        self.note_spacing = 0.01 # spacing between notes in seconds
+        self.gain = 0.05 # default gain in the generated sine wave. pyo multiplier, -1 to 1.
         self.pitch_mapper = PitchMap(data_to_pitch)
 
         if method == "pyo":
@@ -222,6 +226,26 @@ class SoniSeries():
     def gain(self, value):
         self._gain = value;
 
+    @property
+    def note_duration(self):
+        """ How long each individual note will be in seconds."""
+        return self._note_duration
+
+    @note_duration.setter
+    def note_duration(self, value):
+        # Add in min value check
+        self._note_duration = value;
+
+    @property
+    def note_spacing(self):
+        """ The spacing of the notes on average (will adjust based on time) in seconds. """
+        return self._note_spacing
+
+    @note_spacing.setter
+    def note_spacing(self, value):
+        # Add in min value check
+        self._note_spacing = value;
+        
     def sonify(self):
         """
         Perform the sonification, two columns will be added to the data table: asf_pitch, and asf_onsets. 
@@ -230,19 +254,15 @@ class SoniSeries():
         Metadata will also be added to the table giving information about the duration and spacing 
         of the sonified pitches, as well as an adjustable gain.
         """
-        duration = 0.5 # note duration in seconds
-        spacing = 0.01 # spacing between notes in seconds
-        self.gain = 0.05 # default gain in the generated sine wave. pyo multiplier, -1 to 1.
-
         data = self.data
         exptime = np.median(np.diff(data[self.time_col]))
 
         data.meta["asf_exposure_time"] = exptime
-        data.meta["asf_note_duration"] = duration
-        data.meta["asf_spacing"] = spacing
+        data.meta["asf_note_duration"] = self.note_duration
+        data.meta["asf_spacing"] = self.note_spacing
         
         data["asf_pitch"] = self.pitch_mapper(data[self.val_col])
-        data["asf_onsets"] = [x for x in (data[self.time_col] - data[self.time_col][0])/exptime*spacing]
+        data["asf_onsets"] = [x for x in (data[self.time_col] - data[self.time_col][0])/exptime*self.note_spacing]
 
     def _pyo_play(self):
         """

--- a/astronify/utils/pitch_mapping.py
+++ b/astronify/utils/pitch_mapping.py
@@ -19,7 +19,7 @@ __all__ = ['data_to_pitch']
 
 
 def data_to_pitch(data_array, pitch_range=[100,10000], center_pitch=440, zero_point="median",
-                  stretch='linear', minmax_percent=None, minmax_value=None):
+                  stretch='linear', minmax_percent=None, minmax_value=None, invert=False):
     """
     Map data array to audible pitches in the given range, and apply stretch and scaling
     as required.
@@ -49,6 +49,9 @@ def data_to_pitch(data_array, pitch_range=[100,10000], center_pitch=440, zero_po
         The format is [min value, max value], where data values below the min value and above
         the max value are clipped.
         Only one of minmax_percent and minmax_value should be specified.
+    invert : bool
+        Optional, default False.  If True the pitch array is inverted (low pitches become high 
+        and vice versa).
 
     Returns
     -------
@@ -97,10 +100,20 @@ def data_to_pitch(data_array, pitch_range=[100,10000], center_pitch=440, zero_po
     # Performing the transform and then putting it into the pich range
     pitch_array = transform(data_array)
 
+    
+    if invert:
+        pitch_array = 1 - pitch_array
+        
     zero_point = pitch_array[-1]
     pitch_array = pitch_array[:-1]
-    
-    pitch_array = np.multiply((center_pitch - pitch_range[0])/zero_point, pitch_array, out=pitch_array) + pitch_range[0]
+
+          
+    #pitch_array = np.multiply((center_pitch - pitch_range[0])/zero_point, pitch_array, out=pitch_array) + pitch_range[0]
+
+    if ((1/zero_point)*(center_pitch - pitch_range[0]) +  pitch_range[0]) <= pitch_range[1]:
+        pitch_array = (pitch_array/zero_point)*(center_pitch - pitch_range[0]) +  pitch_range[0]
+    else:
+        pitch_array = ((pitch_array-zero_point)/(1-zero_point))*(pitch_range[1] - center_pitch) +  center_pitch
     
     return pitch_array
 


### PR DESCRIPTION
This PR adds a few more user controls to the series sonification (relevant to issue #7):

- Note duration: how long each individual tone is
- Note spacing: the spacing between notes, i.e. the time in seconds that corresponds to the median difference between time bins (mentioned in issue #8)
- Invert: Higher data values (usually flux) can be made to correspond to lower pitches

Also I fixed (hopefully) the way I took the stretched/scaled data values (now floats 0-1) to the pitch values which was buggy. However I am still not confident in what I am doing. @scfleming and @theresadower if you could take a look (lines 113-116 in the pitch mapping function) I would really appreciate it.