### PR TITLE
Updates to simulator.

### DIFF
--- a/astronify/simulator/add_flare_signal.py
+++ b/astronify/simulator/add_flare_signal.py
@@ -5,12 +5,119 @@
 .. moduleauthor:: Scott W. Fleming <fleming@stsci.edu>
 """
 
-def add_flare_signal(fluxes):
+import math
+import numpy as np
+
+def add_flare_signal(fluxes, flare_time, flare_amp, flare_halfwidth):
     """
+    Model is based on Davenport et al.
+    (https://ui.adsabs.harvard.edu/abs/2014ApJ...797..122D/abstract)
+
+    F_rise = 1 + 1.941(t) - 0.175(t^2) - 2.246(t^3) - 1.125(t^4)
+    where t = time at half the maximum flux, after normalizing such that
+    the flux at t=0 is the peak of the flare.
+
+    F_decay = 0.6890*e^(-1.600*t) + 0.3030*e^(-0.2783*t)
+    where t = time at half the maximum flux, after normalizing such that
+    the flux at t=0 is the peak of the flare.
+
     :param fluxes: Array of fluxes to add the flare signal to.
     :type fluxes: numpy.ndarray
+
+    :param flare_time: Time corresponding to the maximum flare flux.
+    :type flare_time: int
+
+    :param flare_amp: The peak (maximum flux) of the flare.
+    :type flare_amp: float
+
+    :param flare_halfwidth: The flare half-width (measured in indices) that
+    corresponds to "t_1/2" in the Davenport et al. flare template.
+    :type flare_halfwidth: index
 
     :returns: numpy.ndarray -- The fluxes with the flare signal added.
     """
 
-    return fluxes
+    # This array will contain the fluxes of the flare to add to the input.
+    fluxes_to_add = np.zeros(fluxes.shape[0])
+
+    # We must be careful if the flare_halfwidth pushes us past the zero'th
+    # index though.  If it does, we temporarily prepend some extra indices.
+    truncated_start = flare_time - flare_halfwidth < 0
+    if truncated_start:
+        n_to_add_rise = abs(flare_time - flare_halfwidth + 1)
+        fluxes_to_add = np.concatenate([np.zeros(n_to_add_rise), fluxes_to_add])
+        # Need to move the 'flare_time' index over now...
+        flare_time += n_to_add_rise
+
+    # Where "n" = 6 in Davenport et al., where the decay phase is defined from
+    # t_1/2 = [0,6], but we may choose to extend further so that the decay gets
+    # as close to zero as possible.
+    n_t12 = 10
+
+    # Need to check if our decay tail will extend past the input array.
+    truncated_end = flare_time + n_t12*flare_halfwidth-1 > fluxes_to_add.shape[0]
+    if truncated_end:
+        n_to_add_decay = (flare_time + n_t12*flare_halfwidth -
+                          fluxes_to_add.shape[0])
+        fluxes_to_add = np.concatenate([np.zeros(n_to_add_decay), fluxes_to_add])
+
+    # Create the normalized part of the rise time.
+    # In the Davenport et al. flare template, the rise part of the flare
+    # is defined from a region extending from -1 * "t_1/2" (defined here as
+    # 'flare_halfwidth') out to 't_1/2' = 0, which is the peak of the flare
+    # (defined here as  'flare_time'.
+    # Therefore, we use Davenport et al. Eqn. 1 to set the RISE fluxes
+    # between 'flare_time-flare_halfwidth' and 'flare_time' indices.
+    #
+    # If we want a flare halfwidth of 4 indices, we need to make a linear step
+    # array from -1. to 0. that is 'halfwidth' in length, e.g.:
+    #   [-1, -0.6667, -0.3333, 0.]
+    # Then apply Davenport et al. Eqn. 1 to this array (now expressed in "t_1/2")
+    #   Eqn. 1 * [-1, -0.6667, -0.3333, 0.]
+    # Then we insert these fluxes into the array at indices:
+    #  [flare_time-flare_halfwidth+1 : flare_time]
+
+    # Generate indices in "t_1/2" units.
+    t12_rise_indices = np.linspace(-1., 0., flare_halfwidth)
+    # Compute fluxes for the rise part.
+    rise_fluxes = (1. + 1.941*t12_rise_indices - 0.175*t12_rise_indices**2. -
+                   2.246*t12_rise_indices**3. - 1.125*t12_rise_indices**4.)
+    # Insert these fluxes into the correct location in our light curve.
+    fluxes_to_add[flare_time-flare_halfwidth+1:flare_time+1] = rise_fluxes
+
+    # Create the normalized part of the decay time.
+    # In Davenport et al., they define their Eqn. 4 from t_1/2 = [0, 6].
+    #
+    # If our halfwidth is 4 indices, then make a linear step array "n"*halfwidth
+    # Davenport et al. defined the decay from [0, 6], so n=6 in their case...
+    #  [0., 0.26086957, 0.52173913, ... , 5.47826087, 5.73913043, 6.]
+    # Then apply Davenport Eqn. 4 to this array expressed in "t_1/2"
+    #  Eqn. 4 * [0., 0.26086957, 0.52173913, ... , 5.47826087, 5.73913043, 6.]
+    #
+    # Then we insert these fluxes into the array of indices:
+    #  [flare_time : flare_time + n*flare_halfwidth-1
+
+    # Generate indices in "t_1/2" units.
+    t12_decay_indices = np.linspace(0., n_t12, n_t12*flare_halfwidth)
+    # Compute fluxes for the decay part.
+    # math.exp() doesn't accept numpy arrays, so using list comprehension...
+    decay_fluxes = np.asarray([(0.6890*math.exp(-1.600*x) +
+                                0.3030*math.exp(-0.2783*x))
+                               for x in t12_decay_indices])
+    # Insert these fluxes into the correct location in our light curve.
+    # Note: the above index range is correct, but in Python you need to go one
+    # extra when slicing, hence 6*flare_halfwidth-1+1 = 6*flare_halfwidth...
+    fluxes_to_add[flare_time: flare_time+n_t12*flare_halfwidth] = decay_fluxes
+
+    # Scale the fluxes to add (which are normalized at this point) by 'flare_amp'
+    fluxes_to_add *= flare_amp
+
+    # If we needed to add some filler indices in the beginning, remove them now.
+    if truncated_start:
+        fluxes_to_add = fluxes_to_add[n_to_add_rise:]
+
+    # If we needed to add some fillter indices at the end, remove them now.
+    if truncated_end:
+        fluxes_to_add = fluxes_to_add[0:fluxes.shape[0]]
+
+    return fluxes + fluxes_to_add

--- a/astronify/simulator/check_flare_params.py
+++ b/astronify/simulator/check_flare_params.py
@@ -1,0 +1,45 @@
+"""
+.. module:: check_flare_params
+   :synopsis: Performs checks on flare parameters to make sure the values
+       are self-consistent (start index isn't larger than the length of the
+       array, amplitude is not negative, etc.)
+
+.. moduleauthor:: Scott W. Fleming <fleming@stsci.edu>
+"""
+
+import argparse
+
+def check_flare_params(n_fluxes, flare_time, flare_amp):
+    """
+    :param n_fluxes: Number of fluxes in the light curve.
+    :type n_fluxes: int
+
+    :param flare_time: Time corresponding to the maximum flare flux.
+    :type flare_time: int
+
+    :param flare_amp: The peak (maximum flux) of the flare.
+    :type flare_amp: float
+    """
+
+    # Flare time index must be less than total numbr of fluxes.
+    if flare_time > n_fluxes:
+        raise argparse.ArgumentTypeError("The flare time at peak flux must be"
+                                         " less than the total number of fluxes"
+                                         " in the simulated light curve."
+                                         " Number of fluxes = " + str(n_fluxes)
+                                         + ", flare time requested is " +
+                                         str(flare_time) + ".")
+
+    # Flare time index must be greater than or equal to zero.
+    if flare_time < 0:
+        raise argparse.ArgumentTypeError("The flare time at peak flux must be"
+                                         " greater than or equal to zero, flare"
+                                         " time requested is " +
+                                         str(flare_time) + ".")
+
+    # The flare amplitude must be greater than zero.
+    if flare_amp <= 0.:
+        raise argparse.ArgumentTypeError("Flare amplitude must be greater than"
+                                         " zero. Requested"
+                                         " flare amplitude = " +
+                                         str(flare_amp) + ".")

--- a/astronify/simulator/example_cmds.sh
+++ b/astronify/simulator/example_cmds.sh
@@ -12,3 +12,6 @@
 # Sinosoidal light curves:
 #python sim_lc.py sine outputs/sine_nonoise.fits -v
 #python sim_lc.py sine outputs/sine_shallow_withnoise.fits -v --sine_amp 1.5 --sine_period 142 -n 0.5
+
+# Flare light curves:
+python sim_lc.py flare outputs/flare_nonoises.fits -v

--- a/astronify/simulator/sim_lc_config.py
+++ b/astronify/simulator/sim_lc_config.py
@@ -21,3 +21,8 @@ class SimLcConfig:
     # Sinusoidal Parameters
     sim_lc_sine_amp = 10.
     sim_lc_sine_period = 50.
+
+    # Flare Parameters
+    sim_lc_flare_time = 10
+    sim_lc_flare_amp = 100.
+    sim_lc_flare_halfwidth = 5

--- a/astronify/simulator/sim_lc_setup_args.py
+++ b/astronify/simulator/sim_lc_setup_args.py
@@ -97,4 +97,23 @@ def sim_lc_setup_args():
                             " sinusoidal signal, specified in the (unitless)"
                             " time axis (flux bins). Default = %(default)s.")
 
+    # Flare-related parameters here.
+    flare_group = parser.add_argument_group("flare", "Parameters for"
+                                            " adding flares.")
+    flare_group.add_argument("--flare_time", type=int,
+                             default=sim_lc_config.sim_lc_flare_time,
+                             dest="flare_time", help="Time corresponding to"
+                             " the maximum flux of the flare, specified"
+                             " as the index of the flux (bin) to use as"
+                             " the peak time. Default = %(default)s.")
+    flare_group.add_argument("--flare_amp", type=float,
+                             default=sim_lc_config.sim_lc_flare_amp,
+                             dest="flare_amp", help="Amplitude (maximum flux)"
+                             " of the flare to add. Default = %(default)s.")
+    flare_group.add_argument("--flare_halfwidth", type=int,
+                             default="flare_halfwidth", help="The flare"
+                             " half-width (measured in indices) that"
+                             " corresponds to 't_1/2' in the Davenport et al."
+                             " flare template.")
+
     return parser

--- a/docs/notebooks/How_To_Use_The_Simulator.ipynb
+++ b/docs/notebooks/How_To_Use_The_Simulator.ipynb
@@ -178,7 +178,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "lc_data = astronify.simulated_lc(\"flare\", visualize=True)"
+    "lc_data = simulator.simulated_lc(\"flare\", visualize=True)"
    ]
   },
   {
@@ -194,7 +194,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "soni_obj = astronify.SoniSeries(lc_data)\n",
+    "soni_obj = series.SoniSeries(lc_data)\n",
     "soni_obj.sonify()\n",
     "soni_obj.play()"
    ]
@@ -212,7 +212,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "lc_data = astronify.simulated_lc(\"flare\", visualize=True, flare_amp=1000., flare_halfwidth=50, flare_time=100)"
+    "lc_data = simulator.simulated_lc(\"flare\", visualize=True, flare_amp=1000., flare_halfwidth=50, flare_time=100)"
    ]
   },
   {
@@ -228,7 +228,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "soni_obj = astronify.SoniSeries(lc_data)\n",
+    "soni_obj = series.SoniSeries(lc_data)\n",
     "soni_obj.sonify()\n",
     "soni_obj.play()"
    ]
@@ -342,7 +342,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.10"
+   "version": "3.8.1"
   }
  },
  "nbformat": 4,

--- a/docs/notebooks/How_To_Use_The_Simulator.ipynb
+++ b/docs/notebooks/How_To_Use_The_Simulator.ipynb
@@ -169,6 +169,74 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "You can add a stellar flare to the data.  Let's add one using the default parameters.  Stellar flares are sudden increases in brightness over a short time."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lc_data = astronify.simulated_lc(\"flare\", visualize=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Time to sonify!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "soni_obj = astronify.SoniSeries(lc_data)\n",
+    "soni_obj.sonify()\n",
+    "soni_obj.play()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can change the amplitude (height) of the flare, and the width.  Let's make one that is 10 times larger in amplitude and lasts 10 times as long.  You can also specify the index that corresponds to the peak of the flare."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lc_data = astronify.simulated_lc(\"flare\", visualize=True, flare_amp=1000., flare_halfwidth=50, flare_time=100)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's give it a listen."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "soni_obj = astronify.SoniSeries(lc_data)\n",
+    "soni_obj.sonify()\n",
+    "soni_obj.play()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "You can also add sinusoidal signals to the data.  Let's create a light curve like this using the default parameters."
    ]
   },
@@ -274,7 +342,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.1"
+   "version": "3.6.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
1.  Initial support for flares added to simulator.
2. Updated simulator notebook to include flare examples.
3. Simulator now adds flare, sinusoidal, and transit input parameters as FITS keywords to the primary header if saving to FITS.
4. Simulator now automatically creates output directory when attempting to save a FITS file if it does not exist.

Known issue:
1.  The flare tail never approaches back down to zero level flux, even if the full half-width is contained within the index, but it gets close.  Since there is typically noise added I'm not sure how important it is to fix.  Perhaps could add a bit that does some linear interpolation from the end of the injected flare to make it match back down to zero flux level smoothly?