### PR TITLE
Changed the theme to the RTD theme and updated the colors

### DIFF
--- a/docs/_static/astronify.css
+++ b/docs/_static/astronify.css
@@ -1,21 +1,28 @@
-@import url("bootstrap-astropy.css");
-
 div.topbar a.brand {
   background: transparent url("astronify-CIRCLE.png") no-repeat 10px 4px;
   background-image: url("astronify-CIRCLE.png"), none;
   background-size: 32px 32px;
 }
 
+div.wy-side-nav-search{
+    background: #00617E;
+}
 
+div.wy-side-scroll{
+    background: #0D4960;
+}
+
+a.reference:hover{
+    background: rgb(11, 61, 78);
+}
 
 .logo{
-    height: 120px;
-    width:120px;
-    margin-left:auto;
-    margin-right: auto;
-    padding-bottom: 20px;
-    margin-top: 15px;
-    
+    height: 120px !important;
+    width:120px !important;
+    margin-left:auto !important;
+    margin-right: auto !important;
+    padding-bottom: 20px !important;
+    margin-top: 15px !important;
 }
 
 .intro{

--- a/docs/_themes/layout.html
+++ b/docs/_themes/layout.html
@@ -1,0 +1,2 @@
+{% extends "!layout.html" %}
+{% set css_files = css_files + [ "_static/astronify.css" ] %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -97,12 +97,15 @@ release = package.__version__
 
 # Add any paths that contain custom themes here, relative to this directory.
 # To use a different custom theme, add the directory containing the theme.
-#html_theme_path = []
+html_theme_path = ["_themes",]
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes. To override the custom theme, set this to the
 # name of a builtin theme or the name of a custom theme in html_theme_path.
-#html_theme = None
+html_theme = 'sphinx_rtd_theme'
+
+def setup_style(app):
+    app.add_stylesheet("astronify.css")
 
 master_doc='contents'
 html_extra_path=['index.html']
@@ -139,7 +142,9 @@ htmlhelp_basename = project + 'doc'
 
 # Static files to copy after template files
 html_static_path = ['_static']
-html_style = 'astronify.css'
+#html_style = 'astronify.css'
+
+html_css_files = ['astronify.css']
 
 
 # -- Options for LaTeX output -------------------------------------------------

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ envlist =
 requires =
     setuptools >= 30.3.0
     pip >= 19.3.1
+    sphinx_rtd_theme >= 0.5.2
 isolated_build = true
 
 [testenv]
@@ -70,6 +71,7 @@ commands =
 changedir = docs
 description = invoke sphinx-build to build the HTML docs
 extras = docs
+deps= sphinx_rtd_theme
 commands =
     pip freeze
     sphinx-build -b html . _build/html


### PR DESCRIPTION
Changed the docs theme to the sphinx_rtd_theme and updated the colors on it. The theme mentioned in #49 has a built-in bar at the top of the screen I cannot figure out how to get rid of that links into all of the projects and sites related to ansible. So I switched to the theme that it was built upon. If needed, I can go back and switch to that theme or figure out how to configure the elements on that link.