### PR TITLE
automatic conversion of data column names to lowercase 

### DIFF
--- a/astronify/series/series.py
+++ b/astronify/series/series.py
@@ -153,10 +153,10 @@ class SoniSeries():
 
 
         if self.time_col not in data_table.columns:
-            raise AttributeError("Input Table must contain a column 'time'")
+            raise AttributeError(f"Input Table must contain time column '{self.time_col}'")
 
         if self.val_col not in data_table.columns:
-            raise AttributeError("Input Table must contain a column 'flux'")
+            raise AttributeError(f"Input Table must contain a value column '{self.val_col}'")
 
         # Removing any masked values as they interfere with the sonification
         if isinstance(data_table[self.val_col], MaskedColumn):

--- a/astronify/series/series.py
+++ b/astronify/series/series.py
@@ -125,7 +125,6 @@ class SoniSeries():
         self.val_col = val_col
         self.data = data
 
-        print(self.data.columns)
         for c in list(self.data.columns):
             self.data.rename_column(c, c.lower())
 
@@ -148,13 +147,18 @@ class SoniSeries():
 
     @data.setter
     def data(self, data_table):
-        assert isinstance(data_table, Table), 'Data must be an astropy.table.Table object.'
+
+        if not isinstance(data_table, Table):
+            raise TypeError('Data must be an astropy.table.Table object.')
 
         for c in list(data_table.columns):
-             data_table.rename_column(c, c.lower())
+            data_table.rename_column(c, c.lower())
 
-        assert "time" in data_table.columns, "Input Table must contain a column 'time'"
-        assert "flux" in data_table.columns, "Input Table must contain a column 'flux'"
+        if "time" not in data_table.columns:
+            raise AttributeError("Input Table must contain a column 'time'")
+
+        if "flux" not in data_table.columns:
+            raise AttributeError("Input Table must contain a column 'flux'")
 
         # Removing any masked values as they interfere with the sonification
         if isinstance(data_table[self.val_col], MaskedColumn):

--- a/astronify/series/series.py
+++ b/astronify/series/series.py
@@ -125,9 +125,6 @@ class SoniSeries():
         self.val_col = val_col
         self.data = data
 
-        for c in list(self.data.columns):
-            self.data.rename_column(c, c.lower())
-
         # Default specs
         self.note_duration = 0.5  # note duration in seconds
         self.note_spacing = 0.01  # spacing between notes in seconds
@@ -154,10 +151,11 @@ class SoniSeries():
         for c in list(data_table.columns):
             data_table.rename_column(c, c.lower())
 
-        if "time" not in data_table.columns:
+
+        if self.time_col not in data_table.columns:
             raise AttributeError("Input Table must contain a column 'time'")
 
-        if "flux" not in data_table.columns:
+        if self.val_col not in data_table.columns:
             raise AttributeError("Input Table must contain a column 'flux'")
 
         # Removing any masked values as they interfere with the sonification

--- a/astronify/series/series.py
+++ b/astronify/series/series.py
@@ -125,6 +125,10 @@ class SoniSeries():
         self.val_col = val_col
         self.data = data
 
+        print(self.data.columns)
+        for c in list(self.data.columns):
+            self.data.rename_column(c, c.lower())
+
         # Default specs
         self.note_duration = 0.5  # note duration in seconds
         self.note_spacing = 0.01  # spacing between notes in seconds
@@ -144,7 +148,13 @@ class SoniSeries():
 
     @data.setter
     def data(self, data_table):
-        assert isinstance(data_table, Table), 'Data must be a Table.'
+        assert isinstance(data_table, Table), 'Data must be an astropy.table.Table object.'
+
+        for c in list(data_table.columns):
+             data_table.rename_column(c, c.lower())
+
+        assert "time" in data_table.columns, "Input Table must contain a column 'time'"
+        assert "flux" in data_table.columns, "Input Table must contain a column 'flux'"
 
         # Removing any masked values as they interfere with the sonification
         if isinstance(data_table[self.val_col], MaskedColumn):

--- a/astronify/series/tests/test_series.py
+++ b/astronify/series/tests/test_series.py
@@ -73,7 +73,7 @@ class TestSoniSeries(object):
         new_data = Table({"foo": [0, 1, 2, 3, 4, 5, 6],
                           "Flux": [1, 2, 1, 2, 5, 3, np.nan]})
     
-        with pytest.raises(AssertionError):
+        with pytest.raises(AttributeError):
             so = SoniSeries(new_data)    
 
     def test_assert_flux_exists(self):
@@ -81,7 +81,7 @@ class TestSoniSeries(object):
         new_data = Table({"time": [0, 1, 2, 3, 4, 5, 6],
                           "bar": [1, 2, 1, 2, 5, 3, np.nan]})
         
-        with pytest.raises(AssertionError):
+        with pytest.raises(AttributeError):
             so = SoniSeries(new_data)
 
     def test_default_parameters(self):

--- a/astronify/series/tests/test_series.py
+++ b/astronify/series/tests/test_series.py
@@ -74,7 +74,7 @@ class TestSoniSeries(object):
                           "Flux": [1, 2, 1, 2, 5, 3, np.nan]})
     
         with pytest.raises(AttributeError):
-            so = SoniSeries(new_data)    
+            SoniSeries(new_data)    
 
     def test_assert_flux_exists(self):
         
@@ -82,7 +82,7 @@ class TestSoniSeries(object):
                           "bar": [1, 2, 1, 2, 5, 3, np.nan]})
         
         with pytest.raises(AttributeError):
-            so = SoniSeries(new_data)
+            SoniSeries(new_data)
 
     def test_default_parameters(self):
         assert self.soni_obj.note_duration == 0.5


### PR DESCRIPTION
`SoniSeries` expects lowercase columns `time` and `flux` in the input astropy Table object. This change automatically converts columns to lowercase in the `data_setter` method. It also adds an assertion that those columns actually exist, refactors the corresponding tests and adds tests for the new functionality.