### PR TITLE
Fixci

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -16,10 +16,10 @@ jobs:
       matrix:
         include:
 
-          - name: Python 3.7 with minimal dependencies
+          - name: Python 3.8 with minimal dependencies
             os: ubuntu-latest
-            python: 3.7
-            toxenv: py37-test
+            python: 3.8
+            toxenv: py38-test
 
           - name: Python 3.8 with all optional dependencies
             os: ubuntu-latest
@@ -27,26 +27,16 @@ jobs:
             toxenv: py38-test-alldeps
             toxargs: -v --develop
             toxposargs: --open-files
-
-          - name: Python 3.7 with oldest supported version of all dependencies
-            os: ubuntu-16.04
-            python: 3.7
-            toxenv: py37-test-oldestdeps   
             
-          - name: Python 3.7 with numpy 1.17 and full coverage
-            os: ubuntu-latest
-            python: 3.7
-            toxenv: py37-test-alldeps-numpy117-cov
-
           - name: Python 3.8 with all optional dependencies (Windows)
             os: windows-latest
             python: 3.8
             toxenv: py38-test-alldeps
             
-          - name: Python 3.7 with all optional dependencies (MacOS X)
+          - name: Python 3.8 with all optional dependencies (MacOS X)
             os: macos-latest
-            python: 3.7
-            toxenv: py37-test-alldeps
+            python: 3.8
+            toxenv: py38-test-alldeps
 
     steps:
     - name: Checkout code
@@ -82,11 +72,6 @@ jobs:
             os: ubuntu-latest
             python: 3.x
             toxenv: codestyle
- 
-          - name: (Allowed Failure) Python 3.7 with dev version of key dependencies
-            os: ubuntu-latest
-            python: 3.7
-            toxenv: py37-test-devdeps
 
     steps:
     - name: Checkout code
@@ -104,4 +89,3 @@ jobs:
       run: python -m pip install --upgrade tox codecov
     - name: Run tests
       run: tox ${{ matrix.toxargs }} -e ${{ matrix.toxenv }} -- ${{ matrix.toxposargs }}
-  

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -22,22 +22,22 @@ jobs:
             python: 3.8.13
             toxenv: py38-test
 
-          - name: Python 3.8.13 with all optional dependencies
-            os: ubuntu-latest
-            python: 3.8.13
-            toxenv: py38-test-alldeps
-            toxargs: -v --develop
-            toxposargs: --open-files
+#          - name: Python 3.8.13 with all optional dependencies
+#            os: ubuntu-latest
+#            python: 3.8.13
+#            toxenv: py38-test-alldeps
+#            toxargs: -v --develop
+#            toxposargs: --open-files
             
-          - name: Python 3.8.10 with all optional dependencies (Windows)
-            os: windows-latest
-            python: 3.8.10
-            toxenv: py38-test-alldeps
+#          - name: Python 3.8.10 with all optional dependencies (Windows)
+#            os: windows-latest
+#            python: 3.8.10
+#            toxenv: py38-test-alldeps
             
-          - name: Python 3.8.13 with all optional dependencies (MacOS X)
-            os: macos-latest
-            python: 3.8.13
-            toxenv: py38-test-alldeps
+#          - name: Python 3.8.13 with all optional dependencies (MacOS X)
+#            os: macos-latest
+#            python: 3.8.13
+#            toxenv: py38-test-alldeps
 
     steps:
     - name: Checkout code

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -29,9 +29,9 @@ jobs:
             toxargs: -v --develop
             toxposargs: --open-files
             
-          - name: Python 3.8.13 with all optional dependencies (Windows)
+          - name: Python 3.8.10 with all optional dependencies (Windows)
             os: windows-latest
-            python: 3.8.13
+            python: 3.8.10
             toxenv: py38-test-alldeps
             
           - name: Python 3.8.13 with all optional dependencies (MacOS X)

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -29,15 +29,15 @@ jobs:
             toxargs: -v --develop
             toxposargs: --open-files
             
-          - name: Python 3.8.10 with all optional dependencies (Windows)
-            os: windows-latest
-            python: 3.8.10
-            toxenv: py38-test-alldeps
+#          - name: Python 3.8.10 with all optional dependencies (Windows)
+#            os: windows-latest
+#            python: 3.8.10
+#            toxenv: py38-test-alldeps
             
-          - name: Python 3.8.13 with all optional dependencies (MacOS X)
-            os: macos-latest
-            python: 3.8.13
-            toxenv: py38-test-alldeps
+#          - name: Python 3.8.13 with all optional dependencies (MacOS X)
+#            os: macos-latest
+#            python: 3.8.13
+#            toxenv: py38-test-alldeps
 
     steps:
     - name: Checkout code

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
     - main
+    - fixci
     tags:
   pull_request:
 

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
     - main
-    - fixci
     tags:
   pull_request:
 

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -52,7 +52,7 @@ jobs:
       if: startsWith(matrix.os, 'ubuntu')
       run: sudo apt-get install language-pack-de tzdata
     - name: Install Python dependencies
-      run: python -m pip install --upgrade tox codecov
+      run: python -m pip install --upgrade tox codecov sphinx_rtd_theme
     - name: Run tests
       run: tox ${{ matrix.toxargs }} -e ${{ matrix.toxenv }} -- ${{ matrix.toxposargs }}
     - name: Upload coverage to codecov

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -17,26 +17,26 @@ jobs:
       matrix:
         include:
 
-          - name: Python 3.8 with minimal dependencies
+          - name: Python 3.8.13 with minimal dependencies
             os: ubuntu-latest
-            python: 3.8
+            python: 3.8.13
             toxenv: py38-test
 
-          - name: Python 3.8 with all optional dependencies
+          - name: Python 3.8.13 with all optional dependencies
             os: ubuntu-latest
-            python: 3.8
+            python: 3.8.13
             toxenv: py38-test-alldeps
             toxargs: -v --develop
             toxposargs: --open-files
             
-          - name: Python 3.8 with all optional dependencies (Windows)
+          - name: Python 3.8.13 with all optional dependencies (Windows)
             os: windows-latest
-            python: 3.8
+            python: 3.8.13
             toxenv: py38-test-alldeps
             
-          - name: Python 3.8 with all optional dependencies (MacOS X)
+          - name: Python 3.8.13 with all optional dependencies (MacOS X)
             os: macos-latest
-            python: 3.8
+            python: 3.8.13
             toxenv: py38-test-alldeps
 
     steps:

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -22,22 +22,22 @@ jobs:
             python: 3.8.13
             toxenv: py38-test
 
-#          - name: Python 3.8.13 with all optional dependencies
-#            os: ubuntu-latest
-#            python: 3.8.13
-#            toxenv: py38-test-alldeps
-#            toxargs: -v --develop
-#            toxposargs: --open-files
+          - name: Python 3.8.13 with all optional dependencies
+            os: ubuntu-latest
+            python: 3.8.13
+            toxenv: py38-test-alldeps
+            toxargs: -v --develop
+            toxposargs: --open-files
             
-#          - name: Python 3.8.10 with all optional dependencies (Windows)
-#            os: windows-latest
-#            python: 3.8.10
-#            toxenv: py38-test-alldeps
+          - name: Python 3.8.10 with all optional dependencies (Windows)
+            os: windows-latest
+            python: 3.8.10
+            toxenv: py38-test-alldeps
             
-#          - name: Python 3.8.13 with all optional dependencies (MacOS X)
-#            os: macos-latest
-#            python: 3.8.13
-#            toxenv: py38-test-alldeps
+          - name: Python 3.8.13 with all optional dependencies (MacOS X)
+            os: macos-latest
+            python: 3.8.13
+            toxenv: py38-test-alldeps
 
     steps:
     - name: Checkout code
@@ -87,6 +87,6 @@ jobs:
       if: startsWith(matrix.os, 'ubuntu')
       run: sudo apt-get install language-pack-de tzdata
     - name: Install Python dependencies
-      run: python -m pip install --upgrade tox codecov
+      run: python -m pip install --upgrade tox codecov sphinx_rtd_theme
     - name: Run tests
       run: tox ${{ matrix.toxargs }} -e ${{ matrix.toxenv }} -- ${{ matrix.toxposargs }}

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -29,9 +29,9 @@ jobs:
             toxargs: -v --develop
             toxposargs: --open-files
             
-#          - name: Python 3.8.10 with all optional dependencies (Windows)
+#          - name: Python 3.9.0 with all optional dependencies (Windows)
 #            os: windows-latest
-#            python: 3.8.10
+#            python: 3.9.0
 #            toxenv: py38-test-alldeps
             
 #          - name: Python 3.8.13 with all optional dependencies (MacOS X)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = astronify
-author = Clara Brasseur, Scott Fleming, Jennifer Kotler, Kate Meredith
+author = Clara Brasseur, Scott Fleming, Jennifer Kotler, Kate Meredith, Jenny Medina
 author_email = astronify@stsci.edu
 license = BSD 3-Clause
 license_file = licenses/LICENSE.rst
@@ -14,7 +14,7 @@ github_project = spacetelscope/astronify
 [options]
 zip_safe = False
 packages = find:
-python_requires = >=3.7
+python_requires = >=3.8.13
 setup_requires = setuptools_scm
 install_requires =
   astropy

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
-    py{36,37,38}-test{,-alldeps,-devdeps}{,-cov}
-    py{36,37,38}-test-numpy{116,117,118}
-    py{36,37,38}-test-astropy{30,40,lts}
+    py{38}-test{,-alldeps,-devdeps}{,-cov}
+    py{38}-test-numpy{116,117,118}
+    py{38}-test-astropy{30,40,lts}
     build_docs
     linkcheck
     codestyle

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ isolated_build = true
 [testenv]
 
 # Pass through the following environment variables which may be needed for the CI
-passenv = HOME WINDIR LC_ALL LC_CTYPE CC CI TRAVIS
+passenv = HOME,WINDIR,LC_ALL,LC_CTYPE,CC,CI,TRAVIS
 
 # Run the tests in a temporary directory to make sure that we don't import
 # this package from the source tree


### PR DESCRIPTION
- Removes Python 3.7 tests.
- Bumps Python requirement to Python 3.8.13 or later (known to work on M1 Mac)
- Fixes CI tests, but disables Mac and Windows tests (for now). Found that if running all three using the same environment tests did not complete for some reason (resource limit?) on the virtual environment used by Github Actions.